### PR TITLE
Bump version

### DIFF
--- a/lightbulb/ext/filament/__init__.py
+++ b/lightbulb/ext/filament/__init__.py
@@ -25,4 +25,4 @@ __all__ = [
     "CommandLike",
 ]
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"


### PR DESCRIPTION
In #1 the dependencies were updated, but not the PyPI version, so no one can use this library with the new version of `lightbulb`.