### PR TITLE
Bump python version upper limit: 3.10 -> 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     license="LGPL-3.0-ONLY",
     install_requires=parse_requirements_file("requirements.txt"),
     include_package_data=True,
-    python_requires=">=3.8.0,<3.11",
+    python_requires=">=3.8.0,<3.12",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Framework :: AsyncIO",


### PR DESCRIPTION
Have tested filament commands and command groups with 3.11 very lightly.